### PR TITLE
Python3 vs Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Rename config_example.dict to config.dict. Then open the file and update the Cli
 Run the main.py script. If you run into any errors, chances are that you have missed one of the requirements.
 
 ``
-python main.py
+python3 main.py
 ``
 
 ## Using the Code


### PR DESCRIPTION
I spent a long time installing the dependencies in python2 with pip and trouble shooting a whole host of errors because of this line "python main.py".  I believe your project is written for python3 so this small change may help new comers to jump in faster with pip3 and avoid erroneous trouble shooting.  Best. - X